### PR TITLE
Add bin/console script to quickly open irb

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+require "irb"
+require "literally"
+
+Literally.init(include: ["#{Dir.pwd}/**/*"], exclude: ["**/excluded.rb"])
+
+IRB.start(__FILE__)


### PR DESCRIPTION
I hope you don't mind having `bin/console` script to quickly open irb with Literally loaded and initialized (useful for experimentation).